### PR TITLE
refactored input sequence

### DIFF
--- a/sample-data/sample-input/edits.json
+++ b/sample-data/sample-input/edits.json
@@ -3,31 +3,23 @@
         "start": 10,
         "end": 20,
         "clipName": "filename1.wav",
-        "filename": "filename1.wav",
-        "label": "Label1",
-        "path": "some/path/to/audio/file"
+        "label": "Label1"
     },
     {
         "start": 30,
         "end": 40,
         "clipName": "filename2.wav",
-        "filename": "filename2.wav",
-        "label": "Label2",
-        "path": "some/path/to/audio/file2"
+        "label": "Label2"
     },{
         "start": 50,
         "end": 60,
         "clipName": "filename3.wav",
-        "filename": "filename3.wav",
-        "label": "Label3",
-        "path": "some/path/to/audio/file3"
+        "label": "Label3"
     },
     {
         "start": 70,
         "end": 80,
         "clipName": "filename2.wav",
-        "filename": "filename2.wav",
-        "label": "Label4",
-        "path": "some/path/to/audio/file2"
+        "label": "Label4"
     }
 ]

--- a/src/example-usage.js
+++ b/src/example-usage.js
@@ -11,12 +11,6 @@ const result = writeEDL({
 	projectName: 'Node Example'
 });
 
-
-
 fs.writeFileSync('./sample-data/sample-output/example-output.adl', result);
 console.log(result);
-
-
-// const expectedADLOutput = fs.readFileSync('./src/mock/example-output.adl',  'utf8').toString();
-// console.log(expectedADLOutput);
 

--- a/src/index.js
+++ b/src/index.js
@@ -185,10 +185,20 @@ const generateEDL = ({
 const getFileList = (edits) =>{
 	const filePaths = new Set();
 	const fileNames = {};
+	// if the edits don't have a path attribute
+	// use clipName as path
+	edits = edits.map((edit)=>{
+		if(!edit.path){
+			edit.path = edit.clipName;
+		}
+		return edit;
+	});
+
 	edits.forEach((edit)=>{
-		filePaths.add(edit['path']);
+		filePaths.add(edit.path);
 		fileNames[edit.path] = edit.clipName;
 	});
+	
 	return {filePaths, fileNames};
 };
 


### PR DESCRIPTION

**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->

addressing Issue https://github.com/bbc/aes31-adl-composer/issues/1 following PR https://github.com/bbc/aes31-adl-composer/pull/6

**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->

removed `path` and `filename` from input sequence, and adjusted the code to use `clipName` instead of file path.

**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->
- Passed tests ✅  
- refactoring it this way keeps compatibility to adding the path attribute. 
- Altho client side we don't bundle the audio with the adl, path attribute compatibility is relevant if we implement server side packaging of the audio files, similar to python script. 
- the module might need a more substantial refactor at a later stage.




<!-- 
## User Story / Context
|As a ...|I want ...|So that ...|
|-|-|-|
|<Who>|<What>|<Why>|

## Acceptance Criteria
- <Criteria to satisfy the PR Issue>

## Definitions of Done
- [ ] Runs locally
- [ ] Runs remotely
- [ ] Test passes
- [ ] Demonstrated
- [ ] Deployed to Cosmos on Test and Live
- [ ] Documentation
  - [ ] Developer Documentation - [repo's README|<link>]
  - [ ] Stakeholder Documentation - [Confluence|<link>]
  - [ ] Operational Documentation - [Runbook|<link>]
- [ ] Peer reviewed by:
-->
